### PR TITLE
Fix deduplication bug/assert.

### DIFF
--- a/DemandLoading/src/Textures/DemandTextureImpl.cpp
+++ b/DemandLoading/src/Textures/DemandTextureImpl.cpp
@@ -480,6 +480,9 @@ void DemandTextureImpl::open()
 {
     std::unique_lock<std::mutex> lock( m_initMutex );
 
+    if (m_masterTexture)
+        m_masterTexture->open();
+
     // Open the image if necessary, fetching the dimensions and other info.
     if( !m_isOpen )
     {


### PR DESCRIPTION
I think I have found a bug regarding the de-duplication of textures. If you create a texture with an image, then a second with the same image, but the second texture gets a request before the first one, then the original 'master texture' isn't open and we get an assert in useSparseTexture() (m_info.isValid is false). I added a couple of lines to the open() method to open the 'master texture' if present and that seems to fix it.